### PR TITLE
 Spring Batch 5 버전 BuilderFactory 빈 사용불가로 애플리케이션 실행 시 에러 발생 조치

### DIFF
--- a/src/main/java/com/fastcampus/pass/batch/FastCampusPassBatchApplication.java
+++ b/src/main/java/com/fastcampus/pass/batch/FastCampusPassBatchApplication.java
@@ -1,44 +1,10 @@
 package com.fastcampus.pass.batch;
 
-import org.springframework.batch.core.Job;
-import org.springframework.batch.core.Step;
-import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
-
-import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
-import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
-import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
 
-@EnableBatchProcessing
 @SpringBootApplication
 public class FastCampusPassBatchApplication  {
-
-    public final JobBuilderFactory jobBuilderFactory;
-    public final StepBuilderFactory stepBuilderFactory;
-
-    public FastCampusPassBatchApplication(JobBuilderFactory jobBuilderFactory,
-                                          StepBuilderFactory stepBuilderFactory) {
-        this.jobBuilderFactory = jobBuilderFactory;
-        this.stepBuilderFactory = stepBuilderFactory;
-    }
-
-    @Bean
-    public Step passStep() {
-        return this.stepBuilderFactory.get("passStep")
-                .tasklet((contribution, chunkContext) -> {
-                    System.out.println("Execute PassStep");
-                    return RepeatStatus.FINISHED;
-                }).build();
-    }
-
-    @Bean
-    public Job passJob() {
-        return this.jobBuilderFactory.get("passJob")
-                .start(passStep())
-                .build();
-    }
 
     public static void main(String[] args) {
         SpringApplication.run(FastCampusPassBatchApplication.class, args);

--- a/src/main/java/com/fastcampus/pass/config/JobConfig.java
+++ b/src/main/java/com/fastcampus/pass/config/JobConfig.java
@@ -1,0 +1,10 @@
+package com.fastcampus.pass.config;
+
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableBatchProcessing
+public class JobConfig {
+
+}

--- a/src/main/java/com/fastcampus/pass/config/PassJobConfig.java
+++ b/src/main/java/com/fastcampus/pass/config/PassJobConfig.java
@@ -1,0 +1,45 @@
+package com.fastcampus.pass.config;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableBatchProcessing
+public class PassJobConfig {
+
+    public static final String JOB_NAME = "passJob";
+    private final JobBuilderFactory jobBuilderFactory;
+    private final StepBuilderFactory stepBuilderFactory;
+
+    @Autowired
+    public PassJobConfig(JobBuilderFactory jobBuilderFactory,
+                         StepBuilderFactory stepBuilderFactory) {
+        this.jobBuilderFactory = jobBuilderFactory;
+        this.stepBuilderFactory = stepBuilderFactory;
+    }
+
+    @Bean
+    public Job passJob() {
+        return jobBuilderFactory.get(JOB_NAME)
+                .start(passStep())
+                .build();
+    }
+
+    @Bean
+    public Step passStep() {
+        return stepBuilderFactory.get("passStep")
+                .tasklet((contribution, chunkContext) -> {
+                    System.out.println("==================== execute passTasklet ====================");
+                    return RepeatStatus.FINISHED;
+                })
+                .build();
+    }
+
+}

--- a/src/main/java/com/fastcampus/pass/runner/JobRunner.java
+++ b/src/main/java/com/fastcampus/pass/runner/JobRunner.java
@@ -1,0 +1,26 @@
+package com.fastcampus.pass.runner;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JobRunner implements CommandLineRunner {
+
+    private final JobLauncher jobLauncher;
+    private final Job passJob;
+
+    public JobRunner(JobLauncher jobLauncher, Job passJob) {
+        this.jobLauncher = jobLauncher;
+        this.passJob = passJob;
+    }
+
+    @Override
+    public void run(String... args) throws Exception {
+        jobLauncher.run(passJob, new JobParametersBuilder()
+                .addLong("time", System.currentTimeMillis())
+                .toJobParameters());
+    }
+}


### PR DESCRIPTION
이 pr은 Job 과 Step 의 BuilderFactory 빈 생성을 해두지 않아 발생된 에러를 조치 한다.

This closes #9 